### PR TITLE
tmux: switch pane jumps to location-based selection

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -82,16 +82,16 @@ bind -n M-q choose-tree -Zw -O name "switch-client -t '%%' \; if-shell -F '#{==:
 # Use Option + Shift + q to move up the list ONLY when tree menu is open
 bind -n M-Q if-shell -F '#{==:#{pane_mode},tree-mode}' 'send-keys Up'
 
-# direct 2x2 pane jumps in current window (w e / s d)
-bind -n M-w select-pane -t :.1 \; if-shell -F '#{==:#{window_zoomed_flag},0}' 'resize-pane -Z' \; set @pane_hud 1 \; run-shell -b "sleep 1.5 && tmux set -u @pane_hud 2>/dev/null; true"
-bind -n M-e select-pane -t :.2 \; if-shell -F '#{==:#{window_zoomed_flag},0}' 'resize-pane -Z' \; set @pane_hud 1 \; run-shell -b "sleep 1.5 && tmux set -u @pane_hud 2>/dev/null; true"
-bind -n M-s select-pane -t :.3 \; if-shell -F '#{==:#{window_zoomed_flag},0}' 'resize-pane -Z' \; set @pane_hud 1 \; run-shell -b "sleep 1.5 && tmux set -u @pane_hud 2>/dev/null; true"
-bind -n M-d select-pane -t :.4 \; if-shell -F '#{==:#{window_zoomed_flag},0}' 'resize-pane -Z' \; set @pane_hud 1 \; run-shell -b "sleep 1.5 && tmux set -u @pane_hud 2>/dev/null; true"
+# direct location-based pane jumps: w/p=top-left, e/[=top-right, s/;=bottom-left, d/'=bottom-right
+bind -n M-w run-shell 'p=$(tmux list-panes -F "##{pane_id} ##{pane_top} ##{pane_left}" | sort -k2,2n -k3,3n | head -1 | cut -d" " -f1); [ -n "$p" ] && tmux select-pane -t "$p"; [ "$(tmux display-message -p "##{window_zoomed_flag}")" = "0" ] && tmux resize-pane -Z; tmux set @pane_hud 1' \; run-shell -b "sleep 1.5 && tmux set -u @pane_hud 2>/dev/null; true"
+bind -n M-e run-shell 'p=$(tmux list-panes -F "##{pane_id} ##{pane_top} ##{pane_left}" | sort -k2,2n -k3,3nr | head -1 | cut -d" " -f1); [ -n "$p" ] && tmux select-pane -t "$p"; [ "$(tmux display-message -p "##{window_zoomed_flag}")" = "0" ] && tmux resize-pane -Z; tmux set @pane_hud 1' \; run-shell -b "sleep 1.5 && tmux set -u @pane_hud 2>/dev/null; true"
+bind -n M-s run-shell 'p=$(tmux list-panes -F "##{pane_id} ##{pane_top} ##{pane_left}" | sort -k2,2nr -k3,3n | head -1 | cut -d" " -f1); [ -n "$p" ] && tmux select-pane -t "$p"; [ "$(tmux display-message -p "##{window_zoomed_flag}")" = "0" ] && tmux resize-pane -Z; tmux set @pane_hud 1' \; run-shell -b "sleep 1.5 && tmux set -u @pane_hud 2>/dev/null; true"
+bind -n M-d run-shell 'p=$(tmux list-panes -F "##{pane_id} ##{pane_top} ##{pane_left}" | sort -k2,2nr -k3,3nr | head -1 | cut -d" " -f1); [ -n "$p" ] && tmux select-pane -t "$p"; [ "$(tmux display-message -p "##{window_zoomed_flag}")" = "0" ] && tmux resize-pane -Z; tmux set @pane_hud 1' \; run-shell -b "sleep 1.5 && tmux set -u @pane_hud 2>/dev/null; true"
 
-bind -n M-p select-pane -t :.1 \; if-shell -F '#{==:#{window_zoomed_flag},0}' 'resize-pane -Z' \; set @pane_hud 1 \; run-shell -b "sleep 1.5 && tmux set -u @pane_hud 2>/dev/null; true"
-bind -n M-[ select-pane -t :.2 \; if-shell -F '#{==:#{window_zoomed_flag},0}' 'resize-pane -Z' \; set @pane_hud 1 \; run-shell -b "sleep 1.5 && tmux set -u @pane_hud 2>/dev/null; true"
-bind -n M-\; select-pane -t :.3 \; if-shell -F '#{==:#{window_zoomed_flag},0}' 'resize-pane -Z' \; set @pane_hud 1 \; run-shell -b "sleep 1.5 && tmux set -u @pane_hud 2>/dev/null; true"
-bind -n M-\' select-pane -t :.4 \; if-shell -F '#{==:#{window_zoomed_flag},0}' 'resize-pane -Z' \; set @pane_hud 1 \; run-shell -b "sleep 1.5 && tmux set -u @pane_hud 2>/dev/null; true"
+bind -n M-p run-shell 'p=$(tmux list-panes -F "##{pane_id} ##{pane_top} ##{pane_left}" | sort -k2,2n -k3,3n | head -1 | cut -d" " -f1); [ -n "$p" ] && tmux select-pane -t "$p"; [ "$(tmux display-message -p "##{window_zoomed_flag}")" = "0" ] && tmux resize-pane -Z; tmux set @pane_hud 1' \; run-shell -b "sleep 1.5 && tmux set -u @pane_hud 2>/dev/null; true"
+bind -n M-[ run-shell 'p=$(tmux list-panes -F "##{pane_id} ##{pane_top} ##{pane_left}" | sort -k2,2n -k3,3nr | head -1 | cut -d" " -f1); [ -n "$p" ] && tmux select-pane -t "$p"; [ "$(tmux display-message -p "##{window_zoomed_flag}")" = "0" ] && tmux resize-pane -Z; tmux set @pane_hud 1' \; run-shell -b "sleep 1.5 && tmux set -u @pane_hud 2>/dev/null; true"
+bind -n M-\; run-shell 'p=$(tmux list-panes -F "##{pane_id} ##{pane_top} ##{pane_left}" | sort -k2,2nr -k3,3n | head -1 | cut -d" " -f1); [ -n "$p" ] && tmux select-pane -t "$p"; [ "$(tmux display-message -p "##{window_zoomed_flag}")" = "0" ] && tmux resize-pane -Z; tmux set @pane_hud 1' \; run-shell -b "sleep 1.5 && tmux set -u @pane_hud 2>/dev/null; true"
+bind -n M-\' run-shell 'p=$(tmux list-panes -F "##{pane_id} ##{pane_top} ##{pane_left}" | sort -k2,2nr -k3,3nr | head -1 | cut -d" " -f1); [ -n "$p" ] && tmux select-pane -t "$p"; [ "$(tmux display-message -p "##{window_zoomed_flag}")" = "0" ] && tmux resize-pane -Z; tmux set @pane_hud 1' \; run-shell -b "sleep 1.5 && tmux set -u @pane_hud 2>/dev/null; true"
 
 # and use C-h and C-l to cycle thru panes
 # bind -r C-h select-window -t :-


### PR DESCRIPTION
## Summary

- Replace index-based `select-pane -t :.N` with coordinate-based selection using `pane_top`/`pane_left`
- M-w/p → top-left, M-e/[ → top-right, M-s/; → bottom-left, M-d/' → bottom-right
- Pane zoom and `@pane_hud` behavior preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)